### PR TITLE
remove =back without =over

### DIFF
--- a/lib/Net/Google/SafeBrowsing3.pm
+++ b/lib/Net/Google/SafeBrowsing3.pm
@@ -1403,8 +1403,6 @@ sub expand_range {
 	return @list;
 }
 
-=back
-
 =head1 CHANGELOG
 
 =over 4


### PR DESCRIPTION
This patch fixes this error that can be seen with `perldoc` or `metacpan`.

```
% perldoc lib/Net/Google/SafeBrowsing3.pm|tail
    under the same terms as Perl itself, either Perl version 5.8.8 or, at your
    option, any later version of Perl 5 you may have available.

POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 1406:
        =back without =over

```
